### PR TITLE
feat: allow signal effect to clean itself up inside callback function

### DIFF
--- a/signals.js
+++ b/signals.js
@@ -13,9 +13,16 @@ export class Signal extends EventTarget {
     }
 
     effect(fn) {
-        fn();
-        this.addEventListener('change', fn);
-        return () => this.removeEventListener('change', fn);
+        const controller = new AbortController()
+        const cleanup = () => controller.abort()
+
+        fn(cleanup)
+        this.addEventListener(
+            'change',
+            () => fn(cleanup), { signal: controller.signal }
+        )
+
+        return cleanup
     }
 
     valueOf () { return this.#value; }


### PR DESCRIPTION
```
// this doesn't work, since the effect runs before the cleanup function is returned
const cleanup = imageSize.effect(() => {
    if (imageSize.value <= 0)
        return

    loadImage()
    cleanup() // throws error
})

// this works now
imageSize.effect((cleanup) => {
    if (imageSize.value <= 0)
        return

    loadImage()
    cleanup()
})
```